### PR TITLE
Adding some nofollow tags

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,6 @@ pygmentsUseClasses: true
 pygmentsCodeFences: true
 pygmentsCodefencesGuessSyntax: true
 paginate: 5
-Copyright: "[Some rights reserved](/copyright/) © 2003 - 2021 [Chris Short](https://linktr.ee/TheChrisShort) • [Terms](/terms/) • [Privacy](/privacy) • [Cookies](/cookie-policy/)"
 permalinks:
     post: ":title/"
 Params:

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,9 +3,9 @@
     <p><a href="/causes/" title="Causes">Causes</a> &bull; <a href="https://devopsish.com/what-is-devops/?utm_source=chrisshort.net&utm_medium=web&utm_campaign=books" title="What is DevOps">What is DevOps</a> &bull; <a href="/long-thoracic-nerve-palsy/" title="Long Thoracic Nerve Palsy">Long Thoracic Nerve Palsy</a> &bull; <a href="/foundation-for-purposeful-living/" title="Foundation for Purposeful Living">Foundation for Purposeful Living</a></p>
     <p>&nbsp;</p>
     {{- if .Site.Copyright }}
-    <span>{{ .Site.Copyright | markdownify }}</span>
+    <span>{{ .Site.Copyright }}</span>
     {{- else }}
-    <span>&copy; 2003 - {{ now.Year }} <a href="{{ "" | absLangURL }}">{{ .Site.Title }}</a></span>
+    <span><a href="/copyright/" title="Copyright CC BY-SA 4.0" rel="nofollow">Some rights reserved</a> © 2003 - {{ dateFormat "2006" now }} <a href="https://linktr.ee/TheChrisShort" title="Chris Short">Chris Short</a> &bull; <a href="/terms/" title="Terms and Conditions" rel="nofollow">Terms</a> &bull; <a href="/privacy/" title="Privacy Policy" rel="nofollow">Privacy</a> &bull; <a href="/cookie-policy/" title="Cookie Policy" rel="nofollow">Cookies</a></span>
     {{- end }}
     <p><div id="wcb" class="wcb carbonbadge"></div>
         <script src="https://unpkg.com/website-carbon-badges@^1/b.min.js" defer></script></p>


### PR DESCRIPTION
- Google Search Console shows the most internal links are to copyright and policy pages
- The nofollow tag has been added to these pages to establish better internal linking hygiene
- Luckily, this theme makes that pretty easy (also year is automatically updated on build)
- Next step might be to run the site through an HTML validator