### PR TITLE
Tweaking snippet from new version of theme

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "hugo --minify"
 
 [context.production.environment]
-HUGO_VERSION = "0.111.3"
+HUGO_VERSION = "0.120.3"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "false"
 
@@ -11,13 +11,13 @@ HUGO_ENABLEGITINFO = "false"
 command = "curl -L 'https://cdn.carbonads.com/carbon.js?serve=CK7D52QU&placement=chrisshortnet' -o assets/js/extended/carbon.js || hugo --minify --enableGitInfo"
 
 [context.split1.environment]
-HUGO_VERSION = "0.111.3"
+HUGO_VERSION = "0.120.3"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "hugo -DF -b $DEPLOY_PRIME_URL"
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.111.3"
+HUGO_VERSION = "0.120.3"
 # Skip all post processing in deploy previews,
 # ignoring any other settings
 [context.deploy-preview.processing]

--- a/themes/PaperMod/layouts/partials/post_meta.html
+++ b/themes/PaperMod/layouts/partials/post_meta.html
@@ -13,5 +13,5 @@
 {{end}}
 
 {{- with ($scratch.Get "meta")}}
-{{- delimit . "&nbsp;·&nbsp;"}}
+{{- delimit . "&nbsp;·&nbsp;" | safeHTML -}}
 {{- end }}


### PR DESCRIPTION
The post metadata includes a number of non-breaking spaces that weren't rendering as HTML (rendered as plaintext). 👎

In the PaperMod theme, it appears the latest version has a Hugo `safeHTML`  inlined with these spaces which fixes the issue. 👍

I need to look into upgrading the theme (if I haven't already which it kinda looks like I haven't). Upgrading through release tarballs is relatively easy assuming there aren't breaking changes in my modifications.