### PR TITLE
adding a render-image.html to help with img width and height

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,6 @@
+{{- $image := .Page.Resources.GetMatch (printf "%s" (.Destination | safeURL)) -}}
+<img
+    src="{{ .Destination | safeURL }}" alt="{{ .Text }}"
+    {{ with $image }}
+    width="{{ $image.Width }}" height="{{ $image.Height }}"
+    {{ end }} />


### PR DESCRIPTION
Source: https://werat.dev/blog/automatic-image-size-attributes-in-hugo/

There might be a better way

Signed-off-by: Chris "Not So" Short <chrisshort@duck.com>